### PR TITLE
Proposal of PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Done
+
+[List of work items including drive-bys]
+
+## QA
+
+- Check out this feature branch
+- Run the site using the command `./run serve`
+- View the site locally in your web browser at: http://0.0.0.0:8001/
+- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
+- [List additional steps to QA the new features or prove the bug has been resolved]
+
+
+## Issue / Card
+
+Fixes #
+
+## Screenshots
+
+[if relevant, include a screenshot]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 - Check out this feature branch
 - Run the site using the command `./run serve`
-- View the site locally in your web browser at: http://0.0.0.0:8001/
+- View the site locally in your web browser at: http://0.0.0.0:port/ (replace port with the correct port in your [project](https://canonical-web-and-design.github.io/practices/project-structure/ports.html))
 - Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
 - [List additional steps to QA the new features or prove the bug has been resolved]
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 - Check out this feature branch
 - Run the site using the command `./run serve`
-- View the site locally in your web browser at: http://0.0.0.0:port/ (replace port with the correct port in your [project](https://canonical-web-and-design.github.io/practices/project-structure/ports.html))
+- View the site locally in your web browser at: http://0.0.0.0:{port}/ (replace port with the correct port in your [project](https://canonical-web-and-design.github.io/practices/project-structure/ports.html))
 - Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
 - [List additional steps to QA the new features or prove the bug has been resolved]
 


### PR DESCRIPTION
As discussed in a [previous catch-up #469](https://github.com/canonical-web-and-design/meeting-notes/issues/469) here I propose this PR template which is used across many of our websites. I created this PR based on our last discussion:

- Some repos, such as private repos, do not need an issue template, therefore we are not adding an issue template.
- However it seems all of our sites do have PRs, and sometimes we missed QA steps.
- This template includes some basic QA steps that are common across most projects.
- Other fields are optional, the user can still override and delete the placeholder content.