### PR TITLE
Add codecov badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Flask website cookiecutter
+
+[![Code coverage](https://codecov.io/gh/canonical-web-and-design/website-boilerplate/branch/master/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/website-boilerplate)
+
 This is a flask cookiecutter to help us quickly set up new flask websites
 
 ## Usage


### PR DESCRIPTION
## Done

Added a codecov badge to the README which should display at the bottom of the main page of the repo.

## QA

- Check out this feature branch
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the badge appears correctly.


## Issue / Card

Fixes web-squad#2986